### PR TITLE
fix(scripts): don't give the backup directory a custom name

### DIFF
--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -21,6 +21,7 @@ begin
     end
 
     set BACKUP (mktemp -d)
+    or abort "could not create temporary directory"
 
     # unset in case this has been set beforehand
     set -e fail

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -20,7 +20,7 @@ begin
         set XDG_DATA_HOME $HOME/.local/share
     end
 
-    set BACKUP (mktemp -d -t dotfiles)
+    set BACKUP (mktemp -d)
 
     # unset in case this has been set beforehand
     set -e fail


### PR DESCRIPTION
`mktemp` has different behaviour for the `-t` flag depending on the distribution, the custom directory name isn't worth the  hassle of dealing with different versions.
