### PR TITLE
ci: don't try to install `rustup`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
             - name: Install formulae
               run: |
                   export HOMEBREW_NO_AUTO_UPDATE=1
-                  brew install bat exa fish fzf jump neovim ripgrep rustup starship vim vivid
+                  brew install bat exa fish fzf jump neovim ripgrep starship vim vivid
 
             - name: Run `bootstrap`
               run: ./scripts/bootstrap


### PR DESCRIPTION
All Rust tools are included in the `macos` images by default.
