### PR TITLE
feat(git): manage local config instead of global config

### DIFF
--- a/git/config
+++ b/git/config
@@ -10,7 +10,5 @@
     ff = only
 [init]
     defaultBranch = main
-[include]
-    path = config_local
 [diff]
     algorithm = histogram


### PR DESCRIPTION
There are tools like `git-credential-manager-core` that add / change values in the global git config file, which then show up as changes to this repo. To avoid this, we can move the config file here to be one that is referenced using `include.path` so that the default global git config file becomes the "local" file that includes user information, specific pagers etc.